### PR TITLE
Update dummy-api.go

### DIFF
--- a/dummy-api.go
+++ b/dummy-api.go
@@ -351,6 +351,10 @@ func process(w http.ResponseWriter, r *http.Request) {
 		i, err := strconv.Atoi(value)
 		if err == nil {
 			if i > 0 {
+				
+				if i > 10000 {
+				    	i = 10000
+				}
 				if verbose {
 					fmt.Println(r.RemoteAddr +
 						" - random-content: " + strconv.Itoa(i) + " chars")
@@ -367,6 +371,10 @@ func process(w http.ResponseWriter, r *http.Request) {
 		i, err := strconv.Atoi(value)
 		if err == nil {
 			if i > 0 {
+				
+				if i > 10000 {
+				    	i = 10000
+				}
 				if verbose {
 					fmt.Println(r.RemoteAddr +
 						" - predictable-content: " + strconv.Itoa(i) + " chars")


### PR DESCRIPTION
By limiting the predictable-content and random-content params to 10,000 it prevents the goserver from being DDOS'ed.